### PR TITLE
feat: Implement student profile management

### DIFF
--- a/app/Livewire/StudentProfileEditor.php
+++ b/app/Livewire/StudentProfileEditor.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Livewire;
+
+use App\Models\StudentProfile;
+use App\Models\User;
+use Illuminate\Support\Facades\Auth;
+use Livewire\Component;
+use Livewire\WithFileUploads;
+
+class StudentProfileEditor extends Component
+{
+    use WithFileUploads;
+
+    public StudentProfile $profile;
+    public ?User $user = null;
+    public $bio;
+    public $skills;
+    public $resume;
+
+    public function mount(User $user = null)
+    {
+        $this->user = $user ?? Auth::user();
+        $this->profile = $this->user->profile()->firstOrNew();
+        $this->bio = $this->profile->bio;
+        $this->skills = $this->profile->skills;
+    }
+
+    public function save()
+    {
+        // Only the student themselves can update their profile
+        if (Auth::id() !== $this->user->id) {
+            abort(403);
+        }
+
+        $this->validate([
+            'bio' => 'nullable|string|max:1000',
+            'skills' => 'nullable|string|max:500',
+            'resume' => 'nullable|file|mimes:pdf,doc,docx|max:2048', // 2MB Max
+        ]);
+
+        $this->profile->user_id = $this->user->id;
+        $this->profile->bio = $this->bio;
+        $this->profile->skills = $this->skills;
+
+        if ($this->resume) {
+            $this->profile->resume_path = $this->resume->store('resumes', 'public');
+        }
+
+        $this->profile->save();
+
+        session()->flash('message', 'Profile successfully updated.');
+    }
+
+    public function render()
+    {
+        return view('livewire.student-profile-editor');
+    }
+}

--- a/app/Models/StudentProfile.php
+++ b/app/Models/StudentProfile.php
@@ -2,18 +2,19 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
-class Placement extends Model
+class StudentProfile extends Model
 {
+    use HasFactory;
+
     protected $fillable = [
-        'student_name',
-        'company',
-        'package',
-        'branch',
-        'year',
         'user_id',
+        'resume_path',
+        'skills',
+        'bio',
     ];
 
     public function user(): BelongsTo

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -4,6 +4,8 @@ namespace App\Models;
 
 // use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Illuminate\Support\Str;
@@ -74,5 +76,15 @@ class User extends Authenticatable
     public function isStudent(): bool
     {
         return $this->role === 'student';
+    }
+
+    public function profile(): HasOne
+    {
+        return $this->hasOne(StudentProfile::class);
+    }
+
+    public function placements(): HasMany
+    {
+        return $this->hasMany(Placement::class);
     }
 }

--- a/database/migrations/2025_08_27_075900_create_student_profiles_table.php
+++ b/database/migrations/2025_08_27_075900_create_student_profiles_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('student_profiles', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->onDelete('cascade');
+            $table->string('resume_path')->nullable();
+            $table->text('skills')->nullable();
+            $table->text('bio')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('student_profiles');
+    }
+};

--- a/database/migrations/2025_08_27_080400_add_user_id_to_placements_table.php
+++ b/database/migrations/2025_08_27_080400_add_user_id_to_placements_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('placements', function (Blueprint $table) {
+            $table->foreignId('user_id')->nullable()->constrained()->onDelete('set null');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('placements', function (Blueprint $table) {
+            $table->dropForeign(['user_id']);
+            $table->dropColumn('user_id');
+        });
+    }
+};

--- a/resources/views/components/layouts/app/sidebar.blade.php
+++ b/resources/views/components/layouts/app/sidebar.blade.php
@@ -36,6 +36,9 @@
         @if (auth()->user()->isStudent())
             <flux:navlist variant="outline">
                 <flux:navlist.group :heading="__('Your Journey')" class="grid">
+                    <flux:navlist.item icon="user-circle" :href="route('profile.edit')"
+                        :current="request()->routeIs('profile.edit')" wire:navigate>{{ __('My Profile') }}
+                    </flux:navlist.item>
                     <flux:navlist.item icon="briefcase" :href="route('placements.students')"
                         :current="request()->routeIs('placements.students')"
                         wire:navigate>{{ __('Placements') }}

--- a/resources/views/livewire/student-profile-editor.blade.php
+++ b/resources/views/livewire/student-profile-editor.blade.php
@@ -1,0 +1,59 @@
+<div>
+    <form wire:submit.prevent="save">
+        <div class="space-y-4">
+            <div>
+                @if (auth()->id() === $user->id)
+                    <h2 class="text-xl font-semibold">Edit Your Profile</h2>
+                    <p class="text-gray-600 dark:text-gray-400">Update your bio, skills, and resume.</p>
+                @else
+                    <h2 class="text-xl font-semibold">Student Profile: {{ $user->name }}</h2>
+                    <p class="text-gray-600 dark:text-gray-400">Viewing the profile of {{ $user->email }}.</p>
+                @endif
+            </div>
+
+            @if (session()->has('message'))
+                <div class="p-4 mb-4 text-sm text-green-700 bg-green-100 rounded-lg dark:bg-green-200 dark:text-green-800" role="alert">
+                    {{ session('message') }}
+                </div>
+            @endif
+
+            <div>
+                <label for="bio" class="block text-sm font-medium text-gray-700 dark:text-gray-300">Bio</label>
+                <textarea id="bio" wire:model="bio" rows="4" class="block w-full mt-1 border-gray-300 rounded-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm dark:bg-gray-800 dark:border-gray-600 dark:text-white" @if(auth()->id() !== $user->id) disabled @endif></textarea>
+                @error('bio') <span class="text-red-500 text-xs">{{ $message }}</span> @enderror
+            </div>
+
+            <div>
+                <label for="skills" class="block text-sm font-medium text-gray-700 dark:text-gray-300">Skills</label>
+                <input type="text" id="skills" wire:model="skills" class="block w-full mt-1 border-gray-300 rounded-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm dark:bg-gray-800 dark:border-gray-600 dark:text-white" placeholder="e.g., PHP, Laravel, JavaScript" @if(auth()->id() !== $user->id) disabled @endif>
+                <p class="mt-2 text-sm text-gray-500">Comma-separated list of your top skills.</p>
+                @error('skills') <span class="text-red-500 text-xs">{{ $message }}</span> @enderror
+            </div>
+
+            <div>
+                <label for="resume" class="block text-sm font-medium text-gray-700 dark:text-gray-300">Resume</label>
+                @if (auth()->id() === $user->id)
+                    <input type="file" id="resume" wire:model="resume" class="block w-full mt-1 text-sm text-gray-900 border border-gray-300 rounded-lg cursor-pointer bg-gray-50 dark:text-gray-400 focus:outline-none dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400">
+                    <div wire:loading wire:target="resume" class="mt-2 text-sm text-gray-500">Uploading...</div>
+                @endif
+                @if ($profile->resume_path)
+                    <p class="mt-2 text-sm text-gray-500">
+                        @if (auth()->id() === $user->id) Current resume: @endif
+                        <a href="{{ Storage::url($profile->resume_path) }}" target="_blank" class="text-indigo-600 hover:underline">View Resume</a>
+                    </p>
+                @else
+                    <p class="mt-2 text-sm text-gray-500">No resume uploaded.</p>
+                @endif
+                @error('resume') <span class="text-red-500 text-xs">{{ $message }}</span> @enderror
+            </div>
+
+            @if (auth()->id() === $user->id)
+                <div>
+                    <button type="submit" class="inline-flex justify-center px-4 py-2 text-sm font-medium text-white bg-indigo-600 border border-transparent rounded-md shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
+                        Save Changes
+                    </button>
+                </div>
+            @endif
+        </div>
+    </form>
+</div>

--- a/resources/views/livewire/students-list.blade.php
+++ b/resources/views/livewire/students-list.blade.php
@@ -160,8 +160,12 @@ new class extends Component {
                             <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{{ $student->branch }}</td>
                             <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{{ $student->year }}</td>
                             <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
+                                @if ($student->user_id)
+                                    <a href="{{ route('students.profile', $student->user_id) }}"
+                                        class="text-green-600 hover:text-green-900">View Profile</a>
+                                @endif
                                 <a href="{{ route('students.edit', $student->id) }}"
-                                    class="text-indigo-600 hover:text-indigo-900">Edit</a>
+                                    class="ml-4 text-indigo-600 hover:text-indigo-900">Edit</a>
                                 <button wire:click="confirmDelete({{ $student->id }})"
                                     class="ml-4 text-red-600 hover:text-red-900">Delete</button>
                             </td>

--- a/routes/web.php
+++ b/routes/web.php
@@ -29,6 +29,15 @@ Route::middleware(['auth'])->group(function () {
     Volt::route('students', 'students-list')->name('students.list');
     Volt::route('students/add', 'import-students')->name('students.add');
     Volt::route('students/edit/{id}', 'student-edit')->name('students.edit');
+
+    // Student Profile
+    Route::get('/profile', \App\Livewire\StudentProfileEditor::class)->name('profile.edit');
+    Route::get('/students/{user}/profile', \App\Livewire\StudentProfileEditor::class)->name('students.profile')->middleware(function ($request, $next) {
+        if (!auth()->user()->isAdmin()) {
+            abort(403);
+        }
+        return $next($request);
+    });
 });
 
 require __DIR__ . '/auth.php';

--- a/tests/Feature/Livewire/StudentProfileTest.php
+++ b/tests/Feature/Livewire/StudentProfileTest.php
@@ -1,0 +1,79 @@
+<?php
+
+use App\Livewire\StudentProfileEditor;
+use App\Models\User;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use Livewire\Livewire;
+
+use function Pest\Laravel\actingAs;
+use function Pest\Laravel\get;
+
+beforeEach(function () {
+    // Create an admin user for testing admin actions
+    $this->admin = User::factory()->create(['role' => 'admin']);
+
+    // Create two student users for testing permissions
+    $this->student1 = User::factory()->create(['role' => 'student']);
+    $this->student2 = User::factory()->create(['role' => 'student']);
+});
+
+test('a student can view their own profile editor', function () {
+    actingAs($this->student1)
+        ->get(route('profile.edit'))
+        ->assertOk()
+        ->assertSeeLivewire(StudentProfileEditor::class);
+});
+
+test('a student can update their profile', function () {
+    Storage::fake('public');
+
+    $file = UploadedFile::fake()->create('resume.pdf', 100, 'application/pdf');
+
+    actingAs($this->student1);
+
+    Livewire::test(StudentProfileEditor::class)
+        ->set('bio', 'This is my new bio.')
+        ->set('skills', 'PHP, Laravel, Testing')
+        ->set('resume', $file)
+        ->call('save');
+
+    $this->student1->refresh();
+
+    $profile = $this->student1->profile;
+    expect($profile)->not->toBeNull();
+    expect($profile->bio)->toBe('This is my new bio.');
+    expect($profile->skills)->toBe('PHP, Laravel, Testing');
+    expect($profile->resume_path)->not->toBeNull();
+
+    Storage::disk('public')->assertExists($profile->resume_path);
+});
+
+test('an admin can view a student profile', function () {
+    actingAs($this->admin)
+        ->get(route('students.profile', $this->student1))
+        ->assertOk()
+        ->assertSee('Student Profile: ' . $this->student1->name);
+});
+
+test('a student cannot view another student profile page', function () {
+    // The route for viewing other profiles is admin-only.
+    // This test ensures a student gets a 'Forbidden' error.
+    actingAs($this->student1)
+        ->get(route('students.profile', $this->student2))
+        ->assertForbidden();
+});
+
+test('a student cannot update another student profile', function () {
+    actingAs($this->student1);
+
+    // This test attempts to update student2's profile while authenticated as student1.
+    // The component should prevent this via the abort(403) call.
+    Livewire::test(StudentProfileEditor::class, ['user' => $this->student2])
+        ->set('bio', 'malicious bio')
+        ->call('save')
+        ->assertForbidden();
+
+    $this->student2->refresh();
+    expect($this->student2->profile)->toBeNull();
+});


### PR DESCRIPTION
This commit introduces a comprehensive student profile feature, allowing students to manage their own professional details.

Key changes:
- Created a `StudentProfile` model and migration to store bio, skills, and resume path.
- Established a one-to-one relationship between `User` and `StudentProfile`.
- Added a `user_id` to the `placements` table to correctly associate placements with users.
- Built a Livewire component for students to edit their profiles, including resume uploads.
- Implemented a read-only view for admins to see student profiles.
- Added routes and navigation links for the new profile pages.
- Wrote a full suite of feature tests to cover the new functionality and authorization rules.